### PR TITLE
Cancel any remaining embedding generation on exceptions

### DIFF
--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -144,6 +144,7 @@ export default function PromptForm() {
                     message: err.message,
                 });
 
+                handleClose();
                 closeToast(progressToastId);
             }
         },


### PR DESCRIPTION
This fixes #8 

<img width="1415" alt="image" src="https://github.com/Amnish04/raggy-chats/assets/78865303/026cf2c5-ebae-4bff-9fc9-fa0e2195f7f7">
